### PR TITLE
kakapo-open: indent relative to the correct line

### DIFF
--- a/kakapo-mode.el
+++ b/kakapo-mode.el
@@ -198,7 +198,6 @@ indentation."
 					; loop if the line we're on is not a blank line.
 					(setq point-end (if above (point-min) (point-max)))
 					(while (and loop-continue (not (eq (point) point-end)))
-						(forward-line (if above -1 1))
 						(beginning-of-line)
 						(setq lw (kakapo-lw))
 						(setq lc (kakapo-lc))
@@ -206,6 +205,7 @@ indentation."
 						(if (not (string= "" lc))
 							(setq loop-continue nil)
 						)
+						(forward-line (if above -1 1))
 					)
 					lw
 				)
@@ -625,7 +625,7 @@ above."
 			(lw-initial (kakapo-lw))
 			(lw "")
 			(lc "")
-			(lw-nearest (kakapo-lw-search above))
+			(lw-nearest (kakapo-lw-search (not above)))
 			(invalid-char (if (kakapo-hard-tab) " " "\t"))
 			(err-msg
 				(concat


### PR DESCRIPTION
I was experiencing very inconvenient behavior on the following example Haskell code:

```haskell
f = do
    foo $ do
        a
        b
        c
    d
```

If I'm on line `d` and press `O`, I expect the indentation of the newly inserted line to match the indentation of line `d`. Instead, the newly inserted line had the indentation of line `c`.