### PR TITLE
give kakapo-mode its own separate word in the modeline

### DIFF
--- a/kakapo-mode.el
+++ b/kakapo-mode.el
@@ -757,7 +757,7 @@ indentation level found above).
 (define-minor-mode kakapo-mode
 	"Stupid TAB character."
 	:init-value nil
-	:lighter "/kkp"
+	:lighter " kkp"
 	:global nil
 	:keymap (let ((map (make-sparse-keymap)))
 			(define-key map (kbd "TAB") 'kakapo-tab)


### PR DESCRIPTION
Fixes the string getting stuck to others in the modeline.